### PR TITLE
Fix serialization issue in CustomOIDCAuthenticator

### DIFF
--- a/components/org.wso2.identity.outbound.oidc.auth.client/src/main/java/org/wso2/identity/outbound/oidc/auth/client/CustomOIDCAuthenticator.java
+++ b/components/org.wso2.identity.outbound.oidc.auth.client/src/main/java/org/wso2/identity/outbound/oidc/auth/client/CustomOIDCAuthenticator.java
@@ -62,12 +62,7 @@ public class CustomOIDCAuthenticator extends AbstractApplicationAuthenticator
         implements FederatedApplicationAuthenticator {
 
     private static final Log log = LogFactory.getLog(CustomOIDCAuthenticator.class);
-    private OIDCOutboundClient oidcOutboundClient;
 
-    public CustomOIDCAuthenticator() {
-
-        this.oidcOutboundClient = new OIDCOutboundClient();
-    }
 
     @Override
     public boolean canHandle(HttpServletRequest request) {
@@ -82,7 +77,7 @@ public class CustomOIDCAuthenticator extends AbstractApplicationAuthenticator
                         .addParamValue(getRequestState(request)).build())
                 .build();
 
-        return oidcOutboundClient.canHandle(req, getAuthenticatorConfig().getParameterMap().get("url"));
+        return OIDCOutboundClient.getInstance().canHandle(req, getAuthenticatorConfig().getParameterMap().get("url"));
     }
 
     @Override
@@ -172,8 +167,8 @@ public class CustomOIDCAuthenticator extends AbstractApplicationAuthenticator
             InitAuthRequest initAuthRequest = InitAuthRequest.newBuilder()
                     .setAuthenticationContext(authenticationContext).build();
 
-            InitAuthResponse initAuthResponse = oidcOutboundClient.initiateAuthenticationRequest(initAuthRequest,
-                    getAuthenticatorConfig().getParameterMap().get("url"));
+            InitAuthResponse initAuthResponse = OIDCOutboundClient.getInstance().initiateAuthenticationRequest(
+                    initAuthRequest, getAuthenticatorConfig().getParameterMap().get("url"));
             if (initAuthResponse != null && initAuthResponse.getIsRedirect()) {
                 response.sendRedirect(initAuthResponse.getRedirectUrl());
             } else {

--- a/components/org.wso2.identity.outbound.oidc.auth.client/src/main/java/org/wso2/identity/outbound/oidc/auth/client/OIDCOutboundClient.java
+++ b/components/org.wso2.identity.outbound.oidc.auth.client/src/main/java/org/wso2/identity/outbound/oidc/auth/client/OIDCOutboundClient.java
@@ -36,6 +36,23 @@ public class OIDCOutboundClient {
 
     private static final Log log = LogFactory.getLog(OIDCOutboundClient.class);
 
+    /**
+     * OIDCOutboundClient lazy holder.
+     */
+    private static class OIDCOutboundClientLazyHolder {
+
+        static final OIDCOutboundClient INSTANCE = new OIDCOutboundClient();
+    }
+
+    /**
+     * Get an OIDCOutboundClient instance.
+     *
+     * @return OIDCOutboundClient object.
+     */
+    public static OIDCOutboundClient getInstance() {
+
+        return OIDCOutboundClientLazyHolder.INSTANCE;
+    }
 
     public Boolean canHandle(Request request, String connectionTarget) {
 


### PR DESCRIPTION
## Purpose

> Use singleton OIDCOutboundClient to fix serialization error when adding to session cache.